### PR TITLE
Give freedom to set default_locale and available_locales instead of forcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,37 @@ form do |f|
   # ...
 end
 
+# You can also set locales to show in tabs
+# For example we want to show English translation fields without tab, and want to show other languages within tabs 
+form do |f|
+  # ...
+  f.inputs do
+    Globalize.with_locale(:en) do
+      f.input :title
+    end
+  end
+  f.inputs "Translated fields" do
+    f.translated_inputs 'ignored title', switch_locale: false, available_locales: (I18n.available_locales - [:en]) do |t|
+      t.input :title
+      t.input :content
+    end
+  end
+  # ...
+end
+
+# You can also set default language tab
+# For example we want to make Bengali translation tab as default
+form do |f|
+  # ...
+  f.inputs "Translated fields" do
+    f.translated_inputs 'ignored title', switch_locale: false, default_locale: :bn do |t|
+      t.input :title
+      t.input :content
+    end
+  end
+  # ...
+end
+
 ```
 If `switch_locale` is set, each tab will be rendered switching locale.
 

--- a/lib/active_admin/globalize/form_builder_extension.rb
+++ b/lib/active_admin/globalize/form_builder_extension.rb
@@ -5,13 +5,12 @@ module ActiveAdmin
 
       def translated_inputs(name = "Translations", options = {}, &block)
         options.symbolize_keys!
-        available_locales = options.fetch(:available_locales, I18n.available_locales.sort)
+        available_locales = options.fetch(:available_locales, I18n.available_locales)
         switch_locale = options.fetch(:switch_locale, false)
-        auto_sort = options.fetch(:auto_sort, true)
         default_locale = options.fetch(:default_locale, I18n.default_locale)
         template.content_tag(:div, class: "activeadmin-translations") do
           template.content_tag(:ul, class: "available-locales") do
-            (auto_sort ? available_locales.sort : available_locales).map do |locale|
+            available_locales.map do |locale|
               default = 'default' if locale == default_locale
               template.content_tag(:li) do
                 I18n.with_locale(switch_locale ? locale : I18n.locale) do
@@ -20,7 +19,7 @@ module ActiveAdmin
               end
             end.join.html_safe
           end <<
-          (auto_sort ? available_locales.sort : available_locales).map do |locale|
+          available_locales.map do |locale|
             translation = object.translations.find { |t| t.locale.to_s == locale.to_s }
             translation ||= object.translations.build(locale: locale)
             fields = proc do |form|

--- a/lib/active_admin/globalize/form_builder_extension.rb
+++ b/lib/active_admin/globalize/form_builder_extension.rb
@@ -5,11 +5,12 @@ module ActiveAdmin
 
       def translated_inputs(name = "Translations", options = {}, &block)
         options.symbolize_keys!
+        available_locales = options.fetch(:available_locales, I18n.available_locales.sort)
         switch_locale = options.fetch(:switch_locale, false)
         auto_sort = options.fetch(:auto_sort, true)
         template.content_tag(:div, class: "activeadmin-translations") do
           template.content_tag(:ul, class: "available-locales") do
-            (auto_sort ? I18n.available_locales.sort : I18n.available_locales).map do |locale|
+            (auto_sort ? available_locales.sort : available_locales).map do |locale|
               default = 'default' if locale == I18n.default_locale
               template.content_tag(:li) do
                 I18n.with_locale(switch_locale ? locale : I18n.locale) do
@@ -18,7 +19,7 @@ module ActiveAdmin
               end
             end.join.html_safe
           end <<
-          (auto_sort ? I18n.available_locales.sort : I18n.available_locales).map do |locale|
+          (auto_sort ? available_locales.sort : available_locales).map do |locale|
             translation = object.translations.find { |t| t.locale.to_s == locale.to_s }
             translation ||= object.translations.build(locale: locale)
             fields = proc do |form|
@@ -42,4 +43,3 @@ module ActiveAdmin
     end
   end
 end
-

--- a/lib/active_admin/globalize/form_builder_extension.rb
+++ b/lib/active_admin/globalize/form_builder_extension.rb
@@ -8,10 +8,11 @@ module ActiveAdmin
         available_locales = options.fetch(:available_locales, I18n.available_locales.sort)
         switch_locale = options.fetch(:switch_locale, false)
         auto_sort = options.fetch(:auto_sort, true)
+        default_locale = options.fetch(:default_locale, I18n.default_locale)
         template.content_tag(:div, class: "activeadmin-translations") do
           template.content_tag(:ul, class: "available-locales") do
             (auto_sort ? available_locales.sort : available_locales).map do |locale|
-              default = 'default' if locale == I18n.default_locale
+              default = 'default' if locale == default_locale
               template.content_tag(:li) do
                 I18n.with_locale(switch_locale ? locale : I18n.locale) do
                   template.content_tag(:a, I18n.t(:"active_admin.globalize.language.#{locale}"), href:".locale-#{locale}", :class => default)


### PR DESCRIPTION
@fabn It will be flexible and useful if you allow to set default_locale and available_locales

A usecase: I want to show English translation fields without tab, and want to show other languages within tabs.

```ruby
    f.inputs do
      Globalize.with_locale(:en) do
        f.input :title
      end
    end
    f.inputs 'Translated fields' do
      f.translated_inputs 'ignored title', default_locale: :'zh-CN', switch_locale: false, available_locales: (I18n.available_locales - ['en']) do |t|
        t.input :title
      end
    end
```