### PR TITLE
Replace .bind(), deprecated in jQuery 3, with .on()

### DIFF
--- a/app/assets/javascripts/active_admin/active_admin_globalize.js.coffee
+++ b/app/assets/javascripts/active_admin/active_admin_globalize.js.coffee
@@ -136,7 +136,7 @@ $ ->
         $tabs.filter('.default').click()
 
   # this is to handle elements created with has_many
-  $("a").bind "click", ->
+  $("a").on "click", ->
     setTimeout(
       -> translations()
       50


### PR DESCRIPTION
jQuery 3 (used on AA 1.1–) deprecates some features, see https://api.jquery.com/category/deprecated/deprecated-3.0/. The only thing used in activeadmin-globalize is `bind`, which was superseded with `on` in 1.7. This changes the deprecated method call.