### PR TITLE
Support multiple translated_inputs

### DIFF
--- a/app/assets/javascripts/active_admin/active_admin_globalize.js.coffee
+++ b/app/assets/javascripts/active_admin/active_admin_globalize.js.coffee
@@ -4,11 +4,12 @@ $ ->
 
     # Hides or shows the + button and the remove button.
     updateLocaleButtonsStatus = ($dom) ->
-      $localeList = $dom.find('.add-locale ul li:not(.hidden)')
-      if $localeList.length == 0
-        $dom.find('.add-locale').hide()
-      else
-        $dom.find('.add-locale').show()
+      $dom.find('.add-locale').each ->
+        $localeList = $(this).find('ul li:not(.hidden)')
+        if $localeList.length == 0
+          $(this).hide()
+        else
+          $(this).show()
 
 
     # Hides or shows the locale tab and its corresponding element in the add menu.
@@ -112,24 +113,25 @@ $ ->
             $('.activeadmin-translations > ul').each ->
               # Get the corresponding fieldsets.
               $fieldsets = $(this).siblings('fieldset')
-              $("li:not(.add-locale) > a", this).each ->
-                # Remove them if the locale is hidden.
-                if $(this).hasClass('hidden')
-                  # check if it's an existing translation otherwise remove it
-                  $currentFieldset = $("fieldset#{$(this).attr('href')}")
-                  $translationId = $('input[id$=_id]', $currentFieldset)
-                  if $translationId.val()
-                    # mark it for database removal appending a _destroy element
-                    $destroy = $('<input/>').attr(
-                      type: 'hidden',
-                      name: $translationId.attr('name').replace('[id]', '[_destroy]'),
-                      id: $translationId.attr('id').replace('_id', '_destroy'),
-                      value: '1'
-                    )
-                    $destroy.appendTo($currentFieldset)
-                  else
-                    # remove the fieldset from dom so it won't be submitted
-                    $fieldsets.filter($(this).attr('href')).remove()
+              $("li:not(.add-locale) > a.hidden", this).each ->
+                # check if it's an existing translation otherwise remove it
+                $currentFieldset = $fieldsets.filter($(this).attr('href'))
+                $translationId = $('input[id$=_id]', $currentFieldset)
+                if !$translationId.val()
+                  # remove the fieldset from dom so it won't be submitted
+                  $fieldsets.filter($(this).attr('href')).remove()
+                else if !$(".activeadmin-translations > ul > li:not(.add-locale) > a[href='#{$(this).attr('href')}']:not(.hidden)").length
+                  # mark it for database removal appending a _destroy element
+                  $destroy = $('<input/>').attr(
+                    type: 'hidden',
+                    name: $translationId.attr('name').replace('[id]', '[_destroy]'),
+                    id: $translationId.attr('id').replace('_id', '_destroy'),
+                    value: '1'
+                  )
+                  $destroy.appendTo($currentFieldset)
+                else
+                  # clear the particular fields for the existing translation
+                  $currentFieldset.find('input[type=text],textarea').val("")
 
         #Initially update the buttons' status
         updateLocaleButtonsStatus($dom)

--- a/lib/active_admin/globalize/form_builder_extension.rb
+++ b/lib/active_admin/globalize/form_builder_extension.rb
@@ -32,6 +32,10 @@ module ActiveAdmin
             inputs_for_nested_attributes(
               for: [:translations, translation ],
               class: "inputs locale locale-#{translation.locale}",
+              # permit_params :translation_attributes => [:name, :description] does
+              # not permit "translation_attributes" => {"en" => {:name =>, "", :description => ""}, "de" => ...}
+              # While the keys can be arbitrary, they must be integers
+              for_options: {child_index: translation.locale.to_s.bytes.select{|b| b != 45}.map{|b| b - 27}.join()},
               &fields
             )
           end.join.html_safe


### PR DESCRIPTION
Use case: we had a previously monolingual application with a model with lots of attributes, presented in a specific order on the admin page. Adding translations, usage of `activeadmin-globalize` would have required to move all translation fields to a single section on the page, breaking earlier order. We wanted to have non-consecutive translated inputs, but it turned out that adding multiple `translated_input`s resulted in trying to add multiple translation records per locale.

This patch makes the field names use keys generated from the locale, rather than the default incrementing integers. This way, even when multiple translation blocks are added, the same key ensures that the POSTed data is interpreted correctly by the server. Most of the changes were actually to the JS side: locale tab rendering and on-submit data filtering.